### PR TITLE
Rails Express branches in index.json aren't marked as `rx: true`...

### DIFF
--- a/gen/gen.go
+++ b/gen/gen.go
@@ -213,7 +213,6 @@ func buildIndex(dataDir string) {
 
 			cleanName := strings.Replace(file, ".7z", "", -1)
 			fileSize := uint64(fsutil.GetSize(filePath))
-			patchedFilePath := path.Join(dataDir, arch, cleanName+"-railsexpress.7z")
 
 			info := findInfo(oldIndex.Data[arch][category].Versions, cleanName)
 
@@ -224,7 +223,7 @@ func buildIndex(dataDir string) {
 					Path:         "/" + arch + "/" + file,
 					Size:         fileSize,
 					Hash:         crypto.FileHash(filePath),
-					RailsExpress: fsutil.IsExist(patchedFilePath),
+					RailsExpress: strings.Contains(filePath, "-railsexpress"),
 				}
 
 				fmtc.Printf("{g}+ %-24s{!} → {c}%s/%s{!}\n", info.Name, arch, category)


### PR DESCRIPTION
https://rbrepo.kaos.io/index.json

As you can see there, every other branch is marked as `rx: true` in the old code -- but its not the ones with "-railsexpress" in the filename.

```
          {
            "name": "2.0.0-p247-railsexpress",
            "file": "2.0.0-p247-railsexpress.7z",
            "path": "/x86_64/2.0.0-p247-railsexpress.7z",
            "size": 11413974,
            "hash": "346aecacb5cd9a29e5b9ccebd53ca4e4fb788702594b15f50c2f4ea7d912f7e7",
            "rx": false
          },
          {
            "name": "2.0.0-p247",
            "file": "2.0.0-p247.7z",
            "path": "/x86_64/2.0.0-p247.7z",
            "size": 11411736,
            "hash": "241dd723d817a10f676cd359fecac0f686dff776f62167e35d8c7ec472e30b2c",
            "rx": true
          },
          {
            "name": "2.0.0-p353-railsexpress",
            "file": "2.0.0-p353-railsexpress.7z",
            "path": "/x86_64/2.0.0-p353-railsexpress.7z",
            "size": 11313758,
            "hash": "bb3a708586e4203b8e2ce6901752bb94f218e3adacb81b97e76fba4057a7733b",
            "rx": false
          },
          {
            "name": "2.0.0-p353",
            "file": "2.0.0-p353.7z",
            "path": "/x86_64/2.0.0-p353.7z",
            "size": 11309985,
            "hash": "629e3c2f4704c6ec9845fa6de31ce82f49d86c2866013086bc2b762270ba4b18",
            "rx": true
          },
```

This seemed a bit strange to me. :)