### PR TITLE
cli 0.16.0 • gen 0.8.1 • clone 0.5.1

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -618,6 +618,21 @@ func installCommand(rubyVersion string) {
 
 	// //////////////////////////////////////////////////////////////////////////////// //
 
+	checkBinaryTask := &Task{
+		Desc:    "Checking binary",
+		Handler: checkBinaryTaskHandler,
+	}
+
+	_, err = checkBinaryTask.Start(info.Name, getUnpackDirPath())
+
+	if err != nil {
+		fmtc.NewLine()
+		terminal.PrintErrorMessage(err.Error())
+		exit(1)
+	}
+
+	// //////////////////////////////////////////////////////////////////////////////// //
+
 	if isVersionInstalled(info.Name) {
 		if knf.GetB(RBENV_ALLOW_OVERWRITE) && options.GetB(OPT_REINSTALL) {
 			err = os.RemoveAll(getVersionPath(info.Name))
@@ -781,6 +796,17 @@ func unpackTaskHandler(args ...string) (string, error) {
 	}
 
 	return "", nil
+}
+
+func checkBinaryTaskHandler(args ...string) (string, error) {
+	version := args[0]
+	unpackDir := args[1]
+
+	binary := unpackDir + "/" + version + "/bin/ruby"
+
+	err := exec.Command(binary, "--version").Start()
+
+	return "", err
 }
 
 func installGemTaskHandler(args ...string) (string, error) {

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -51,7 +51,7 @@ import (
 
 const (
 	APP  = "RBInstall"
-	VER  = "0.15.0"
+	VER  = "0.16.0"
 	DESC = "Utility for installing prebuilt ruby versions to rbenv"
 )
 
@@ -250,6 +250,7 @@ func prepare() {
 	loadConfig()
 	validateConfig()
 	configureProxy()
+	setEnvVars()
 
 	signal.Handlers{
 		signal.INT: intSignalHandler,
@@ -275,6 +276,23 @@ func configureProxy() {
 	os.Setenv("HTTPS_PROXY", knf.GetS(PROXY_URL))
 
 	req.Global.Transport = &http.Transport{Proxy: http.ProxyURL(proxyURL)}
+}
+
+// setEnvVars set environment variables if rbenv is not initialized
+func setEnvVars() {
+	ev := env.Get()
+
+	if ev.GetS("RBENV_ROOT") != "" {
+		return
+	}
+
+	rbenvDir := knf.GetS(RBENV_DIR)
+	newPath := rbenvDir + "/bin:"
+	newPath += rbenvDir + "/libexec:"
+	newPath += ev.GetS("PATH")
+
+	os.Setenv("RBENV_ROOT", rbenvDir)
+	os.Setenv("PATH", newPath)
 }
 
 // checkPerms check user for sudo

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -205,10 +205,11 @@ func Init() {
 		fmtc.NewLine()
 	}
 
+	prepare()
+
 	if options.GetB(OPT_REHASH) {
 		rehashShims()
 	} else {
-		prepare()
 		fetchIndex()
 		process(args)
 	}

--- a/clone/clone.go
+++ b/clone/clone.go
@@ -32,7 +32,7 @@ import (
 
 const (
 	APP  = "RBInstall Clone"
-	VER  = "0.5.0"
+	VER  = "0.5.1"
 	DESC = "Utility for cloning RBInstall repository"
 )
 

--- a/common/rbinstall.spec
+++ b/common/rbinstall.spec
@@ -144,7 +144,7 @@ rm -rf %{buildroot}
 
 %changelog
 * Fri Aug 04 2017 Anton Novojilov <andy@essentialkaos.com> - 0.16.0-0
-- Added rehash support for uninitialized rbenv
+- [cli] Added rehash support for uninitialized rbenv
 - [cli|gen|clone] ek package updated to latest version
 
 * Thu May 25 2017 Anton Novojilov <andy@essentialkaos.com> - 0.15.0-0

--- a/common/rbinstall.spec
+++ b/common/rbinstall.spec
@@ -145,6 +145,7 @@ rm -rf %{buildroot}
 %changelog
 * Fri Aug 04 2017 Anton Novojilov <andy@essentialkaos.com> - 0.16.0-0
 - [cli] Added rehash support for uninitialized rbenv
+- [cli] Checking Ruby binary after unpacking
 - [cli|gen|clone] ek package updated to latest version
 
 * Thu May 25 2017 Anton Novojilov <andy@essentialkaos.com> - 0.15.0-0

--- a/common/rbinstall.spec
+++ b/common/rbinstall.spec
@@ -44,7 +44,7 @@
 
 Summary:         Utility for installing prebuilt ruby to rbenv
 Name:            rbinstall
-Version:         0.15.0
+Version:         0.16.0
 Release:         0%{?dist}
 Group:           Applications/System
 License:         EKOL
@@ -70,7 +70,7 @@ Utility for installing different prebuilt versions of ruby to rbenv.
 %package gen
 
 Summary:         Utility for generating RBInstall index
-Version:         0.8.0
+Version:         0.8.1
 Release:         0%{?dist}
 Group:           Development/Tools
 
@@ -82,7 +82,7 @@ Utility for generating RBInstall index.
 %package clone
 
 Summary:         Utility for cloning RBInstall repository
-Version:         0.5.0
+Version:         0.5.1
 Release:         0%{?dist}
 Group:           Development/Tools
 
@@ -143,6 +143,10 @@ rm -rf %{buildroot}
 ###############################################################################
 
 %changelog
+* Fri Aug 04 2017 Anton Novojilov <andy@essentialkaos.com> - 0.16.0-0
+- Added rehash support for uninitialized rbenv
+- [cli|gen|clone] ek package updated to latest version
+
 * Thu May 25 2017 Anton Novojilov <andy@essentialkaos.com> - 0.15.0-0
 - [cli|gen|clone] ek package updated to v9
 - [cli] z7 package updated to v6

--- a/gen/gen.go
+++ b/gen/gen.go
@@ -32,7 +32,7 @@ import (
 
 const (
 	APP  = "RBInstall Gen"
-	VER  = "0.8.0"
+	VER  = "0.8.1"
 	DESC = "Utility for generating RBInstall index"
 )
 

--- a/install.sh
+++ b/install.sh
@@ -11,7 +11,7 @@
 # /$$$$$$| $$ \  $$|  $$$$$$/   | $$  | $$  | $$| $$$$$$$$| $$$$$$$$| $$$$$$$$| $$  | $$
 #|______/|__/  \__/ \______/    |__/  |__/  |__/|________/|________/|________/|__/  |__/
 #
-#                            EK UTILITY INSTALLER v1.1.0
+#                            EK UTILITY INSTALLER v1.1.1
 #
 ########################################################################################
 
@@ -215,7 +215,7 @@ action() {
 
   if [[ $? -ne 0 ]] ; then
     show "${CL_RED}+${CL_NORM} $desc"
-    error "\nError occured with last action. Install process will be interrupted.\n"
+    error "\nError occurred with last action. Install process will be interrupted.\n"
     exit 1
   else
     show "${CL_GREEN}+${CL_NORM} $desc"
@@ -282,13 +282,13 @@ requireDEB() {
   fi
 }
 
-# Require root priveleges
+# Require root privileges
 #
 # Code: No
 # Echo: No
 requireRoot() {
   if [[ $(id -u) != "0" ]] ; then
-    error "Superuser priveleges is required for install"
+    error "Superuser privileges is required for install"
     exit 1
   fi
 }


### PR DESCRIPTION
#### New Features
* `[cli]` Added rehash support for uninitialized rbenv
* `[cli]` Checking Ruby binary after unpacking

#### Improvements
* `[cli|gen|clone]` ek package updated to latest version

#### Bugfixes
* `[cli]` Fixed setting environment variables for rehash command (option `--rehash`)