### PR TITLE
Version 0.17.0

### DIFF
--- a/cli/task.go
+++ b/cli/task.go
@@ -60,7 +60,7 @@ func (t *Task) showSpinner() {
 SPINNERLOOP:
 	for {
 		for i, frame := range spinnerFrames {
-			fmtc.Printf("{y}%s {!}%s...", frame, t.Desc)
+			fmtc.Printf("{y}%s {!}%s… ", frame, t.Desc)
 			time.Sleep(framesDelay[i] * time.Millisecond)
 			fmtc.Printf("\r")
 

--- a/common/rbinstall.knf
+++ b/common/rbinstall.knf
@@ -31,17 +31,17 @@
 
 [gems]
 
-  # Update rubygems gem to latest version
+  # Update rubygems gem
   rubygems-update: true
+
+  # Update rubygems gem to given version
+  rubygems-version: 2.6.14
 
   # Allow gems update
   allow-update: true
 
-  # Add --no-ri to install command
-  no-ri: true
-
-  # Add --no-rdoc to install command
-  no-rdoc: true
+  # Add --no-document to install/update command
+  no-document: true
 
   # Source for gem install without scheme
   source: gems.kaos.io

--- a/common/rbinstall.spec
+++ b/common/rbinstall.spec
@@ -44,7 +44,7 @@
 
 Summary:         Utility for installing prebuilt ruby to rbenv
 Name:            rbinstall
-Version:         0.16.1
+Version:         0.17.0
 Release:         0%{?dist}
 Group:           Applications/System
 License:         EKOL
@@ -56,7 +56,7 @@ BuildRoot:       %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
 Requires:        rbenv ca-certificates p7zip >= 15
 
-BuildRequires:   golang >= 1.8
+BuildRequires:   golang >= 1.9
 
 Provides:        %{name} = %{version}-%{release}
 
@@ -143,6 +143,11 @@ rm -rf %{buildroot}
 ###############################################################################
 
 %changelog
+* Tue Nov 07 2017 Anton Novojilov <andy@essentialkaos.com> - 0.17.0-0
+- [cli] Deprecated 'no-ri' and 'no-rdoc' in configuration file
+- [cli] Fixed compatibility with latest version of RubyGems gem
+- [cli] Code refactoring
+
 * Wed Oct 11 2017 Anton Novojilov <andy@essentialkaos.com> - 0.16.1-0
 - [cli] Fixed output for 'rbenv rehash' errors
 - [cli] Improved commands errors logging

--- a/common/rbinstall.spec
+++ b/common/rbinstall.spec
@@ -144,8 +144,10 @@ rm -rf %{buildroot}
 
 %changelog
 * Tue Nov 07 2017 Anton Novojilov <andy@essentialkaos.com> - 0.17.0-0
-- [cli] Deprecated 'no-ri' and 'no-rdoc' in configuration file
-- [cli] Fixed compatibility with latest version of RubyGems gem
+- [cli] Now required version of rubygems gem can be defined through 
+  configuration file
+- [cli] 'gems:no-ri' and 'gems:no-rdoc' options replaced by 'gems:no-document'
+- [cli] Minor UI improvements
 - [cli] Code refactoring
 
 * Wed Oct 11 2017 Anton Novojilov <andy@essentialkaos.com> - 0.16.1-0

--- a/common/rbinstall.spec
+++ b/common/rbinstall.spec
@@ -144,6 +144,7 @@ rm -rf %{buildroot}
 
 %changelog
 * Tue Nov 07 2017 Anton Novojilov <andy@essentialkaos.com> - 0.17.0-0
+- [cli] Fixed bug with updating gems with empty gem list
 - [cli] Now required version of rubygems gem can be defined through 
   configuration file
 - [cli] 'gems:no-ri' and 'gems:no-rdoc' options replaced by 'gems:no-document'


### PR DESCRIPTION
#### New Features
* `[cli]` Now required version of rubygems gem can be defined through configuration file

#### Improvements
* `[cli]` `gems:no-ri` and `gems:no-rdoc` options replaced by `gems:no-document`
* `[cli]` Minor UI improvements
* `[cli]` Code refactoring

#### Bugfixes
* `[cli]` Fixed bug with updating gems with empty gem list