### PR TITLE
Version 0.21.5

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -55,7 +55,7 @@ import (
 // App info
 const (
 	APP  = "RBInstall"
-	VER  = "0.21.4"
+	VER  = "0.21.5"
 	DESC = "Utility for installing prebuilt Ruby versions to rbenv"
 )
 
@@ -1095,7 +1095,7 @@ func runGemCmd(rubyVersion, cmd, gem, gemVersion string) (string, error) {
 	}
 
 	if knf.GetS(GEMS_SOURCE) != "" {
-		gemCmd.Args = append(gemCmd.Args, "--clear-sources", "--source", getGemSourceURL())
+		gemCmd.Args = append(gemCmd.Args, "--clear-sources", "--source", getGemSourceURL(rubyVersion))
 	}
 
 	output, err := gemCmd.CombinedOutput()
@@ -1136,19 +1136,19 @@ func runGemCmd(rubyVersion, cmd, gem, gemVersion string) (string, error) {
 }
 
 // updateRubygems update rubygems to defined version
-func updateRubygems(version, rgVersion string) error {
+func updateRubygems(rubyVersion, gemVersion string) error {
 	var gemCmd *exec.Cmd
 
-	rubyPath := getVersionPath(version)
+	rubyPath := getVersionPath(rubyVersion)
 
-	if rgVersion == "latest" {
+	if gemVersion == "latest" {
 		gemCmd = exec.Command(rubyPath+"/bin/ruby", rubyPath+"/bin/gem", "update", "--system")
 	} else {
-		gemCmd = exec.Command(rubyPath+"/bin/ruby", rubyPath+"/bin/gem", "update", "--system", rgVersion)
+		gemCmd = exec.Command(rubyPath+"/bin/ruby", rubyPath+"/bin/gem", "update", "--system", gemVersion)
 	}
 
 	if knf.GetS(GEMS_SOURCE) != "" {
-		gemCmd.Args = append(gemCmd.Args, "--clear-sources", "--source", getGemSourceURL())
+		gemCmd.Args = append(gemCmd.Args, "--clear-sources", "--source", getGemSourceURL(rubyVersion))
 	}
 
 	output, err := gemCmd.CombinedOutput()
@@ -1535,7 +1535,11 @@ func getAlignSpaces(t string, l int) string {
 }
 
 // getGemSourceURL return url of gem source
-func getGemSourceURL() string {
+func getGemSourceURL(rubyVersion string) string {
+	if strings.HasPrefix(rubyVersion, "1.8") {
+		return "http://" + knf.GetS(GEMS_SOURCE)
+	}
+
 	if !options.GetB(OPT_GEMS_INSECURE) && knf.GetB(GEMS_SOURCE_SECURE, false) {
 		return "https://" + knf.GetS(GEMS_SOURCE)
 	}

--- a/common/rbinstall.spec
+++ b/common/rbinstall.spec
@@ -144,7 +144,7 @@ rm -rf %{buildroot}
 
 %changelog
 * Fri Aug 16 2019 Anton Novojilov <andy@essentialkaos.com> - 0.21.5-0
-- [cli] Always use unsecure source for 1.8.x
+- [cli] Always use insecure source for 1.8.x
 
 * Fri Aug 16 2019 Anton Novojilov <andy@essentialkaos.com> - 0.21.4-0
 - [cli] Disabled installation of the latest version of bundler gem for old

--- a/common/rbinstall.spec
+++ b/common/rbinstall.spec
@@ -44,7 +44,7 @@
 
 Summary:         Utility for installing prebuilt Ruby to rbenv
 Name:            rbinstall
-Version:         0.21.4
+Version:         0.21.5
 Release:         0%{?dist}
 Group:           Applications/System
 License:         EKOL
@@ -143,6 +143,9 @@ rm -rf %{buildroot}
 ################################################################################
 
 %changelog
+* Fri Aug 16 2019 Anton Novojilov <andy@essentialkaos.com> - 0.21.5-0
+- [cli] Always use unsecure source for 1.8.x
+
 * Fri Aug 16 2019 Anton Novojilov <andy@essentialkaos.com> - 0.21.4-0
 - [cli] Disabled installation of the latest version of bundler gem for old
   versions of Ruby


### PR DESCRIPTION
#### Improvements
* `[cli]` Always use insecure source for 1.8.x (_due to dropped SSLv3 support_)
